### PR TITLE
fix: 解决网络请求重定向返回相对地址导致无法请求的问题

### DIFF
--- a/src/swpp/NetworkFileHandler.ts
+++ b/src/swpp/NetworkFileHandler.ts
@@ -191,25 +191,18 @@ export class FiniteConcurrencyFetcher implements NetworkFileHandler {
                     const location = response.headers.location
                     if (!location) {
                         reject(new Error(`GET ${url} Error: 返回了 ${response.statusCode} 但没有包含 Location 字段`))
-                    } else if (location.startsWith('/')) {
-                        const rightIndex = location.indexOf('/', 8)
-                        const host = rightIndex < 0 ? url : location.substring(0, rightIndex)
-                        this.request(host + location, onTimeout)
-                            .then(response => resolve(response))
-                            .catch(err => reject(err))
-                    } else if (/^https?:\/\//.test(location)) {
-                        this.request(location, onTimeout)
-                            .then(response => resolve(response))
-                            .catch(err => reject(err))
                     } else {
-                        const lastIndex = url.lastIndexOf('/')
-                        let base;
-                        if (lastIndex < 8) {
-                            base = url + '/' + location;
-                        } else {
-                            base = url.substring(0, lastIndex + 1) + location;
+                        // 判断是绝对路径还是相对路径
+                        const isAbsolutePath = location.startsWith('http://') || location.startsWith('https://') || location.startsWith('//')
+                        let new_location = location
+                        if (!isAbsolutePath) {
+                            // 从 URL 中获取协议和主机名
+                            const protocol = url.split('://')[0] || 'https'
+                            const host = url.split('/')[2]
+                            // 拼接新的 URL
+                            new_location = `${protocol}://${host}${location}`
                         }
-                        this.request(base, onTimeout)
+                        this.request(new_location, onTimeout)
                             .then(response => resolve(response))
                             .catch(err => reject(err))
                     }


### PR DESCRIPTION
修改后的代码仍然报错，原因是试图从`location`取出`host`，但是本身就是一个相对路径，所以无法获取到。

我尝试从前方的`url`参数中获取主机号，并且考虑了是`//`还是`/`开头的地址（前者一般为绝对，后者一般为相对）

还有可能出现的问题就是，不以`/`开头的相对地址，我搜了一下，有极少数情况会出现以下`location`：

/login ← 最常见的相对路径（根路径）

../page ← 少见，但合法（上级路径）

next/page ← 少见，但也合法（相对当前路径）

除此之外，我个人感觉还可以判断一下多次重定向，因为有的网页会报错，重定向次数过多。