### PR TITLE
使用URL类直接处理所有相对地址或者绝对地址，实现重定向最大次数限制

### DIFF
--- a/src/swpp/NetworkFileHandler.ts
+++ b/src/swpp/NetworkFileHandler.ts
@@ -191,27 +191,20 @@ export class FiniteConcurrencyFetcher implements NetworkFileHandler {
                     const location = response.headers.location
                     if (!location) {
                         reject(new Error(`GET ${url} Error: 返回了 ${response.statusCode} 但没有包含 Location 字段`))
-                    } else if (location.startsWith('/')) {
-                        const rightIndex = url.indexOf('/', 8)
-                        const host = rightIndex < 0 ? url : url.substring(0, rightIndex)
-                        this.request(host + location, onTimeout)
-                            .then(response => resolve(response))
-                            .catch(err => reject(err))
-                    } else if (/^https?:\/\//.test(location)) {
-                        this.request(location, onTimeout)
-                            .then(response => resolve(response))
-                            .catch(err => reject(err))
                     } else {
-                        const lastIndex = url.lastIndexOf('/')
-                        let locationUrl;
-                        if (lastIndex < 8) {
-                            locationUrl = url + '/' + location;
-                        } else {
-                            locationUrl = url.substring(0, lastIndex + 1) + location;
+                        try {
+                            // 使用 URL 构造器处理所有跳转路径（包括相对路径）
+                            const base = new URL(url);
+                            const new_location = new URL(location, base).toString();
+
+                            // 进行请求
+                            this.request(new_location, onTimeout)
+                                .then(response => resolve(response))
+                                .catch(err => reject(err));
+                        
+                        } catch (err) {
+                            reject(new Error(`GET ${url} Error: 构建重定向地址失败 - ${err}`));
                         }
-                        this.request(new URL(locationUrl).href, onTimeout)
-                            .then(response => resolve(response))
-                            .catch(err => reject(err))
                     }
                 } else {
                     const bufferArray: Buffer[] = []

--- a/src/swpp/NetworkFileHandler.ts
+++ b/src/swpp/NetworkFileHandler.ts
@@ -169,7 +169,7 @@ export class FiniteConcurrencyFetcher implements NetworkFileHandler {
         return [url]
     }
 
-    private request(url: string, onTimeout?: () => void): Promise<Response> {
+    private request(url: string, onTimeout?: () => void, redirectCount: number = 0): Promise<Response> {
         if (!/^(https?):\/\/([^!@#$%^&*?.\s-]([^!@#$%^&*?.\s]{0,63}[^!@#$%^&*?.\s])?\.)+[a-z]{2,6}\/?/.test(url)) {
             throw new RuntimeException(exceptionNames.invalidValue, '传入了一个非法的 URL', {url})
         }
@@ -193,12 +193,19 @@ export class FiniteConcurrencyFetcher implements NetworkFileHandler {
                         reject(new Error(`GET ${url} Error: 返回了 ${response.statusCode} 但没有包含 Location 字段`))
                     } else {
                         try {
+                            // 设置最大重定向次数
+                            const MAX_REDIRECT_COUNT = 20
+                            if (redirectCount > MAX_REDIRECT_COUNT) {
+                                reject(new Error(`GET ${url} Error: 重定向次数过多，超过 ${MAX_REDIRECT_COUNT} 次`))
+                                return
+                            }
+
                             // 使用 URL 构造器处理所有跳转路径（包括相对路径）
                             const base = new URL(url);
                             const new_location = new URL(location, base).toString();
 
                             // 进行请求
-                            this.request(new_location, onTimeout)
+                            this.request(new_location, onTimeout, redirectCount + 1)
                                 .then(response => resolve(response))
                                 .catch(err => reject(err));
                         
@@ -230,7 +237,7 @@ export class FiniteConcurrencyFetcher implements NetworkFileHandler {
             }
         })
         responsePromise.finally(() => {
-            utils.printInfo('FETCHER', `GET ${url}: ${(Date.now() - startTime) / 1000}s`)
+            utils.printInfo('FETCHER', `GET ${url} : ${(Date.now() - startTime) / 1000}s`)
         })
         return responsePromise
     }

--- a/src/swpp/NetworkFileHandler.ts
+++ b/src/swpp/NetworkFileHandler.ts
@@ -12,6 +12,8 @@ export interface NetworkFileHandler {
 
     /** 最大并发量 */
     limit: number
+    /** 最大重定向次数 */ 
+    redirectLimit: number
     /** 超时时间（毫秒） */
     timeout: number
     /** 拉取文件时使用的 referer */
@@ -58,6 +60,7 @@ export class FiniteConcurrencyFetcher implements NetworkFileHandler {
 
     limit = 100
     timeout = 5000
+    redirectLimit = 10
     referer = 'https://swpp.example.com'
     userAgent = 'swpp-backends'
     headers = {}
@@ -194,9 +197,8 @@ export class FiniteConcurrencyFetcher implements NetworkFileHandler {
                     } else {
                         try {
                             // 设置最大重定向次数
-                            const MAX_REDIRECT_COUNT = 20
-                            if (redirectCount > MAX_REDIRECT_COUNT) {
-                                reject(new Error(`GET ${url} Error: 重定向次数过多，超过 ${MAX_REDIRECT_COUNT} 次`))
+                            if (redirectCount > this.redirectLimit) {
+                                reject(new Error(`GET ${url} Error: 重定向次数过多，超过 ${this.redirectLimit} 次`))
                                 return
                             }
 


### PR DESCRIPTION
使用URL类直接处理所有相对地址或者绝对地址，实现重定向最大次数限制，添加到配置项中。重定向部分没测试，佬你再看看再修改修改，我个人感觉是没问题的。

URL类是完全可以实现的，我在浏览器也测试过，测试结果如下：

![image](https://github.com/user-attachments/assets/43e24a14-c905-4a1e-afe2-bc7495878e3c)
![image](https://github.com/user-attachments/assets/5f8ed204-8a85-42a9-bba6-e37cc2d4ce71)
![image](https://github.com/user-attachments/assets/23ecf665-7669-4a4a-bb93-a429335544a5)
